### PR TITLE
add doc generation, fix for global apidoc install and flexible poison version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /deps
 erl_crash.dump
 *.ez
+/doc

--- a/lib/mix/tasks/compile.apidoc.ex
+++ b/lib/mix/tasks/compile.apidoc.ex
@@ -47,17 +47,26 @@ defmodule Mix.Tasks.Compile.Apidoc do
   end
 
   defp run_apidoc(node_bin, apidoc_bin, params) do
-    if File.exists? apidoc_bin do
-      case System.cmd(node_bin, [apidoc_bin | params]) do
-        {_, 0} ->
-          Mix.Shell.IO.info "Generated apidoc"
-        _error ->
-          Mix.raise "apidoc responded with an error"
-      end
+    if File.exists?(apidoc_bin) do
+      exec_apidoc(node_bin, apidoc_bin, params)
     else
-      Mix.raise "Could not find apidoc executable '#{apidoc_bin}'. " <>
-                "Run 'npm install' or set the 'apidoc_bin' config parameter " <>
-                "in your 'mix.exs' to a different apidoc executable."
+      apidoc_global = System.find_executable(apidoc_bin)
+      if apidoc_global |> is_nil do
+        Mix.raise "Could not find apidoc executable '#{apidoc_bin}'. " <>
+                  "Run 'npm install' or set the 'apidoc_bin' config parameter " <>
+                  "in your 'mix.exs' to a different apidoc executable."
+      else
+        exec_apidoc(node_bin, apidoc_global, params)
+      end
     end
   end
+
+  defp exec_apidoc(node_bin, apidoc_bin, params) do
+    node_bin
+    |> System.cmd([apidoc_bin | params])
+    |> _handle_result
+  end
+
+  defp _handle_result({_, 0}), do: Mix.Shell.IO.info "Generated apidoc"
+  defp _handle_result(_error), do: Mix.raise "apidoc responded with an error"
 end

--- a/mix.exs
+++ b/mix.exs
@@ -24,6 +24,6 @@ defmodule MixApidoc.Mixfile do
   end
 
   def deps do
-    [poison: "~> 1.5 or ~> 2.0"]
+    [poison: "~> 1.5 or ~> 2.0 or ~> 3.0"]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,7 @@ defmodule MixApidoc.Mixfile do
      elixir: "~> 1.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
+     docs: [extras: ["README.md"]],
      deps: deps]
   end
 
@@ -24,6 +25,10 @@ defmodule MixApidoc.Mixfile do
   end
 
   def deps do
-    [poison: "~> 1.5 or ~> 2.0 or ~> 3.0"]
+    [
+      {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0"},
+      {:earmark, "~> 0.1", only: :dev},
+      {:ex_doc, "~> 0.11", only: :dev}
+    ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,1 +1,3 @@
-%{"poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], []}}
+%{"earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.12.0", "b774aabfede4af31c0301aece12371cbd25995a21bb3d71d66f5c2fe074c603f", [:mix], [{:earmark, "~> 0.2", [hex: :earmark, optional: false]}]},
+  "poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], []}}


### PR DESCRIPTION
The main problem for me was the global apidoc install was not working for obvious reason that the fix for windows introduced as we would have to correctly perform `System.find_executable`. What do you think of this change @sldab ?