### PR TITLE
add ability to specify extra cli args and fix 1.4 warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,15 @@ apidoc_bin: "apidoc"
 ```
 
 Apart from those mix task specific parameters, you can set all apidoc parameters
-as described on the [apidoc](http://apidocjs.com "apidoc/#configuration-settings")
+as described on the [apidoc](http://apidocjs.com/#configuration)
 webpage.
+
+Additionally, you can specify additional command line arguments by specifying
+the following configuration parameter in the config:
+
+```elixir
+extra_args: ["-e", "admin", "-t", "/path/to/custom/template"]
+```
 
 ## Running the task
 

--- a/lib/mix/tasks/compile.apidoc.ex
+++ b/lib/mix/tasks/compile.apidoc.ex
@@ -9,6 +9,7 @@ defmodule Mix.Tasks.Compile.Apidoc do
   @default_input_dir Path.join(~w"web controllers")
   @default_output_dir  Path.join(~w"priv static apidoc")
 
+  @doc false
   def run(_) do
 
     config = Mix.Project.config[:apidoc]
@@ -21,14 +22,12 @@ defmodule Mix.Tasks.Compile.Apidoc do
     apidoc_bin  = config[:apidoc_bin] || Path.join(System.cwd(), @default_apidoc_bin)
     input_dir   = config[:input_dir]  || @default_input_dir
     output_dir  = config[:output_dir] || @default_output_dir
+    extra_args  = config[:extra_args] || []
 
     config_json =
       config
       |> Enum.into(%{})
-      |> Map.delete(:node_bin)
-      |> Map.delete(:apidoc_bin)
-      |> Map.delete(:input_dir)
-      |> Map.delete(:output_dir)
+      |> Map.drop(~w(node_bin apidoc_bin input_dir output_dir extra_args)a)
       |> Poison.encode!
 
     build_dir = Mix.Project.build_path
@@ -42,7 +41,7 @@ defmodule Mix.Tasks.Compile.Apidoc do
     IO.write apidoc_json, config_json
     File.close apidoc_json
 
-    params = ["-i", input_dir, "-o", output_dir, "-c", build_dir]
+    params = ["-i", input_dir, "-o", output_dir, "-c", build_dir] ++ extra_args
     run_apidoc(node_bin, apidoc_bin, params)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -6,12 +6,12 @@ defmodule MixApidoc.Mixfile do
      version: "0.3.0",
      description: "A mix task that triggers apidoc to create documentation " <>
                   "for RESTful web APIs from inline code annotations.",
-     package: package,
+     package: package(),
      elixir: "~> 1.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      docs: [extras: ["README.md"]],
-     deps: deps]
+     deps: deps()]
   end
 
   def package do


### PR DESCRIPTION
hey @sldab this is a quick pr that fixes 1.4 warnings as well as adds supports for passing additional arguments to apidoc binary. I don't think/know its possible to specify some of the cli args as part of apidoc.json. My particular use case was to exclude some of the controllers using `-e` / `--exclude-filters` arg so that apidoc is not generated for those