### PR TITLE
fix version check for phoenix

### DIFF
--- a/lib/mix/tasks/compile.apidoc.ex
+++ b/lib/mix/tasks/compile.apidoc.ex
@@ -92,7 +92,7 @@ defmodule Mix.Tasks.Compile.Apidoc do
   end
 
   defp get_apidoc_bin(config) do
-    phx_ver_req = Application.spec(:phoenix, :vsn) |> to_string
+    phx_ver_req = get_phx_version()
     cond do
       config[:apidoc_bin] != nil ->
         config[:apidoc_bin]
@@ -104,7 +104,7 @@ defmodule Mix.Tasks.Compile.Apidoc do
   end
 
   defp get_input_dir(config) do
-    phx_ver_req = Mix.Project.config[:deps][:phoenix]
+    phx_ver_req = get_phx_version()
     app_name = Mix.Project.config[:app] |> Atom.to_string
     cond do
       config[:input_dir] != nil ->
@@ -115,4 +115,6 @@ defmodule Mix.Tasks.Compile.Apidoc do
         Path.join(~w"web controllers")
     end
   end
+
+  defp get_phx_version, do: Application.spec(:phoenix, :vsn) |> to_string
 end

--- a/lib/mix/tasks/compile.apidoc.ex
+++ b/lib/mix/tasks/compile.apidoc.ex
@@ -92,6 +92,7 @@ defmodule Mix.Tasks.Compile.Apidoc do
   end
 
   defp get_apidoc_bin(config) do
+    phx_ver_req = Application.spec(:phoenix, :vsn) |> to_string
     phx_ver_req = Mix.Project.config[:deps][:phoenix]
     cond do
       config[:apidoc_bin] != nil ->

--- a/lib/mix/tasks/compile.apidoc.ex
+++ b/lib/mix/tasks/compile.apidoc.ex
@@ -93,7 +93,6 @@ defmodule Mix.Tasks.Compile.Apidoc do
 
   defp get_apidoc_bin(config) do
     phx_ver_req = Application.spec(:phoenix, :vsn) |> to_string
-    phx_ver_req = Mix.Project.config[:deps][:phoenix]
     cond do
       config[:apidoc_bin] != nil ->
         config[:apidoc_bin]


### PR DESCRIPTION
@sldab the problem with existing code is that deps can be specified in couple different ways:

```elixir
{:phoenix, "1.3.0"}

{:phoenix, "1.3.0", override: true}

{:phoenix, github: "phoenixframework/phoenix"}
```

This PR basically fixes for scenarios like 2nd or 3rd.